### PR TITLE
Fix: Remove check during wallet creation.

### DIFF
--- a/app/src/main/java/com/nighthawkapps/wallet/android/ui/setup/LandingFragment.kt
+++ b/app/src/main/java/com/nighthawkapps/wallet/android/ui/setup/LandingFragment.kt
@@ -18,7 +18,6 @@ import com.nighthawkapps.wallet.android.ui.setup.WalletSetupViewModel.WalletSetu
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import java.lang.IllegalStateException
 
 class LandingFragment : BaseFragment<FragmentLandingBinding>() {
 
@@ -89,11 +88,6 @@ class LandingFragment : BaseFragment<FragmentLandingBinding>() {
 
             try {
                 val initializer = walletSetup.newWallet()
-                if (!initializer.accountsCreated) {
-                    binding.buttonPositive.isEnabled = true
-                    binding.buttonPositive.setText(R.string.landing_button_primary)
-                    throw IllegalStateException("New wallet should result in accounts table being created")
-                }
                 mainActivity?.startSync(initializer)
 
                 binding.buttonPositive.isEnabled = true

--- a/buildSrc/src/main/java/com/nighthawkapps/wallet/android/Dependencies.kt
+++ b/buildSrc/src/main/java/com/nighthawkapps/wallet/android/Dependencies.kt
@@ -91,7 +91,7 @@ object Deps {
     object Zcash {
         const val ANDROID_WALLET_PLUGINS = "cash.z.ecc.android:zcash-android-wallet-plugins:1.0.0"
         const val KOTLIN_BIP39 = "cash.z.ecc.android:kotlin-bip39:1.0.1"
-        const val SDK = "cash.z.ecc.android:zcash-android-sdk:1.3.0-beta10"
+        const val SDK = "cash.z.ecc.android:zcash-android-sdk:1.3.0-beta11"
     }
 
     object Misc {


### PR DESCRIPTION
Fixes a bug during "new wallet" creation.

Prior to this change, the effect is the user will see an error while creating a wallet. Although the account is technically still created in the background, the process is confusing and disorienting. This fixes the problem by removing the check that was being done on a flag that is no longer used or necessary.

Rather than [relying on a flag](https://github.com/zcash/zcash-android-wallet-sdk/blob/fb2e9cff51b4e14ea1ae622a6f5ff406d5a45705/src/main/java/cash/z/ecc/android/sdk/Initializer.kt#L130), missing accounts are now [discovered by the verifySetup function](https://github.com/zcash/zcash-android-wallet-sdk/blob/master/src/main/java/cash/z/ecc/android/sdk/block/CompactBlockProcessor.kt#L380). The problem here was that the old flag was not removed and was still being checked but no longer updated by the SDK. The fix is to simply remove the flag because it is not needed because it was replaced by a more robust verification.