### PR TITLE
v1.0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 1.0.30 *(2021-11-08)*
+------------------------------------
+- Long tap on transaction under Wallet History now copies tx. id to clipboard.
+- Fix char count when typing memo.
+- Upgrade dependencies.
+
 Version 1.0.29 *(2021-10-27)*
 ------------------------------------
 - Add support to Buy ZEC via MoonPay.

--- a/app/src/main/java/com/nighthawkapps/wallet/android/ui/history/TransactionViewHolder.kt
+++ b/app/src/main/java/com/nighthawkapps/wallet/android/ui/history/TransactionViewHolder.kt
@@ -158,9 +158,18 @@ class TransactionViewHolder<T : ConfirmedTransaction>(itemView: View) : Recycler
 
     private fun onTransactionLongPressed(transaction: ConfirmedTransaction) {
         val mainActivity = itemView.context as MainActivity
-        transaction.toAddress?.let {
-            mainActivity.copyText(it, "Transaction Address")
+        toTxId(transaction.rawTransactionId).let {
+            mainActivity.copyText(it.toString(), "Transaction ID")
         }
+    }
+
+    private fun toTxId(tx: ByteArray?): String? {
+        if (tx == null) return null
+        val sb = StringBuilder(tx.size * 2)
+        for (i in (tx.size - 1) downTo 0) {
+            sb.append(String.format("%02x", tx[i]))
+        }
+        return sb.toString()
     }
 
     private inline fun str(@StringRes resourceId: Int) = itemView.context.getString(resourceId)

--- a/buildSrc/src/main/java/com/nighthawkapps/wallet/android/Dependencies.kt
+++ b/buildSrc/src/main/java/com/nighthawkapps/wallet/android/Dependencies.kt
@@ -9,8 +9,8 @@ object Deps {
     const val buildToolsVersion = "31.0.0"
     const val minSdkVersion = 23
     const val targetSdkVersion = 31
-    const val versionName = "1.0.29"
-    const val versionCode = 1_00_29_800 // last digits are alpha(0XX) beta(2XX) rc(4XX) release(8XX). Ex: 1_08_04_401 is an release candidate build of version 1.8.4 and 1_08_04_800 would be the final release.
+    const val versionName = "1.0.30"
+    const val versionCode = 1_00_30_800 // last digits are alpha(0XX) beta(2XX) rc(4XX) release(8XX). Ex: 1_08_04_401 is an release candidate build of version 1.8.4 and 1_08_04_800 would be the final release.
     const val packageName = "com.nighthawkapps.wallet.android"
 
     object AndroidX {
@@ -18,7 +18,7 @@ object Deps {
         const val APPCOMPAT = "androidx.appcompat:appcompat:1.3.1"
         const val BIOMETRICS = "androidx.biometric:biometric:1.2.0-alpha03"
         const val CONSTRAINT_LAYOUT = "androidx.constraintlayout:constraintlayout:2.1.1"
-        const val CORE_KTX = "androidx.core:core-ktx:1.6.0"
+        const val CORE_KTX = "androidx.core:core-ktx:1.7.0"
         const val FRAGMENT_KTX = "androidx.fragment:fragment-ktx:1.3.6"
         const val LEGACY = "androidx.legacy:legacy-support-v4:1.0.0"
         const val MULTIDEX = "androidx.multidex:multidex:2.0.1"
@@ -39,7 +39,7 @@ object Deps {
             }
         }
 
-        object Lifecycle : Version("2.4.0-rc01") {
+        object Lifecycle : Version("2.4.0") {
             val LIFECYCLE_RUNTIME_KTX = "androidx.lifecycle:lifecycle-runtime-ktx:$version"
         }
 

--- a/fastlane/metadata/android/en-US/changelogs/10030800.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10030800.txt
@@ -1,0 +1,3 @@
+- Long tap on transaction under Wallet History now copies tx. id to clipboard.
+- Fix char count when typing memo.
+- Upgrade dependencies.


### PR DESCRIPTION
- Long tap on transaction under Wallet History now copies tx. id to clipboard.
- Fix char count when typing memo.
- Upgrade dependencies.